### PR TITLE
Optional intellij version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,12 @@ dependencies {
   compile 'com.google.code.gson:gson:2.8.1'
 }
 
+def intellijVersion = 'IC-2017.1.5'
+if (project.hasProperty('intellij.version')) {
+  intellijVersion = getProperty('intellij.version')
+}
+
 intellij {
-  version 'IC-2017.1.5'
+  version intellijVersion
 }
 version '0.1'


### PR DESCRIPTION
I use other intellij version. How about set intellij version by `gradle -Pintellij.version=vvvv buildPlugin` ?